### PR TITLE
Fixed validity condition

### DIFF
--- a/src/main/java/net/unknowndomain/alea/systems/lexarcana2/LexArcana2Options.java
+++ b/src/main/java/net/unknowndomain/alea/systems/lexarcana2/LexArcana2Options.java
@@ -30,7 +30,7 @@ public class LexArcana2Options extends RpgSystemOptions
     @Override
     public boolean isValid()
     {
-        return !(isHelp() || (firstDice == null && secondDice != null) || (secondDice == null ||  thirdDice != null));
+        return !(isHelp() || (firstDice == null && secondDice != null) || (secondDice == null && thirdDice != null));
     }
 
     public Integer getFirstDice()


### PR DESCRIPTION
There's an issue in the validity condition for the third optional dice, it was always invalid if set. (had || instead of && )